### PR TITLE
feat: ヘッダーをレスポンシブ対応に変更

### DIFF
--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -2,9 +2,11 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
 
 export function Navigation() {
   const pathname = usePathname();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const navItems = [
     { href: "/events", label: "イベント一覧" },
@@ -14,19 +16,78 @@ export function Navigation() {
     { href: "/admin", label: "管理画面" },
   ];
 
+  const toggleMenu = () => {
+    setIsMenuOpen(!isMenuOpen);
+  };
+
+  const closeMenu = () => {
+    setIsMenuOpen(false);
+  };
+
   return (
     <nav className="bg-gray-800 text-white shadow-lg">
       <div className="container mx-auto px-4">
         <div className="flex items-center justify-between h-16">
-          <Link href="/" className="text-xl font-bold">
+          {/* ロゴ */}
+          <Link href="/" className="text-xl font-bold z-10">
             Portal.C
           </Link>
-          <div className="flex space-x-4">
+
+          {/* デスクトップメニュー (md以上で表示) */}
+          <div className="hidden md:flex space-x-4">
             {navItems.map((item) => (
               <Link
                 key={item.href}
                 href={item.href}
                 className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                  pathname === item.href
+                    ? "bg-gray-900 text-white"
+                    : "text-gray-300 hover:bg-gray-700 hover:text-white"
+                }`}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+
+          {/* ハンバーガーボタン (mdより小さい画面で表示) */}
+          <button
+            onClick={toggleMenu}
+            className="md:hidden z-10 p-2 rounded-md text-gray-300 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-white"
+            aria-label="メニュー"
+            aria-expanded={isMenuOpen}
+          >
+            <svg
+              className="h-6 w-6"
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              {isMenuOpen ? (
+                <path d="M6 18L18 6M6 6l12 12" />
+              ) : (
+                <path d="M4 6h16M4 12h16M4 18h16" />
+              )}
+            </svg>
+          </button>
+        </div>
+
+        {/* モバイルメニュー (mdより小さい画面で表示) */}
+        <div
+          className={`md:hidden transition-all duration-300 ease-in-out overflow-hidden ${
+            isMenuOpen ? "max-h-96 opacity-100" : "max-h-0 opacity-0"
+          }`}
+        >
+          <div className="px-2 pt-2 pb-3 space-y-1">
+            {navItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                onClick={closeMenu}
+                className={`block px-3 py-2 rounded-md text-base font-medium transition-colors ${
                   pathname === item.href
                     ? "bg-gray-900 text-white"
                     : "text-gray-300 hover:bg-gray-700 hover:text-white"


### PR DESCRIPTION
- スマホ・タブレット表示でハンバーガーメニューを実装
- 768px以下（md未満）でハンバーガーアイコン表示
- モバイルメニューにスライドアニメーション追加
- メニュークリック時に自動で閉じる機能を実装
- デスクトップでは従来通りの横並びメニュー表示