### PR TITLE
Add admin user invitation feature via ZITADEL API

### DIFF
--- a/.kiro/specs/zitadel-user-invitation/design.md
+++ b/.kiro/specs/zitadel-user-invitation/design.md
@@ -1,0 +1,46 @@
+# Technical Design: ZITADEL User Invitation
+
+## Overview
+Admin-driven user invitation via ZITADEL v2 API, following Portal.C's existing patterns (server actions, admin layout, spindle-ui components).
+
+## Architecture
+
+### New Files
+1. **`lib/zitadel/admin-api.ts`** - ZITADEL Management API client
+   - `createZitadelUser(givenName, familyName, email)` → calls `POST {ZITADEL_ISSUER}/v2/users`
+   - `assignUserGrant(userId, role)` → calls `POST {ZITADEL_ISSUER}/management/v1/users/{userId}/grants`
+   - Authenticates with service user PAT via `Authorization: Bearer` header
+
+2. **`app/actions/users.ts`** - Server action
+   - `inviteUserAction(prevState, formData)` → validates input, calls ZITADEL API, assigns role
+   - Pattern: matches `createEventAction` (isAdmin check, FormData extraction, error/success state)
+
+3. **`components/admin/InviteUserForm.tsx`** - Client component
+   - Pattern: matches `CreateEventForm` (useActionState, SubmitButton, spindle-ui Button)
+   - Fields: givenName, familyName, email
+
+4. **`app/admin/invite/page.tsx`** - Admin page
+   - Server component with isAdmin guard
+   - Renders InviteUserForm
+
+### Modified Files
+5. **`app/admin/layout.tsx`** - Add "メンバー招待" nav link
+6. **`app/admin/page.tsx`** - Add dashboard card for invitation
+
+### Environment Variables
+- `ZITADEL_SERVICE_USER_PAT` - Service user Personal Access Token
+- `ZITADEL_PROJECT_ID` - Project ID for role assignment via user grants
+
+## API Flow
+```
+Admin submits form
+  → Server Action validates input
+  → POST {ZITADEL_ISSUER}/v2/users (create user, sendCode for email verification)
+  → POST {ZITADEL_ISSUER}/management/v1/users/{userId}/grants (assign "member" role)
+  → Return success/error to UI
+```
+
+## Security
+- PAT stored server-side only (env var)
+- Admin role check in both layout (redirect) and server action (return error)
+- Input validation: email format, required fields

--- a/.kiro/specs/zitadel-user-invitation/requirements.md
+++ b/.kiro/specs/zitadel-user-invitation/requirements.md
@@ -1,8 +1,48 @@
 # Requirements Document
 
-## Project Description (Input)
-Admin user invitation feature: Administrators can create new ZITADEL users from Portal.C's custom UI. The system uses ZITADEL v2 API (POST /v2/users) to create human users with "member" role. Admin fills in user details (name, email), ZITADEL sends verification email automatically (sendCode). After the invited user verifies email and logs in, ensureMemberOnSignIn() creates the Firestore member record as usual. Requires service user PAT for ZITADEL API authentication.
+## Introduction
+This feature enables Portal.C administrators to invite new users directly from the application's custom admin UI. The system creates human users in ZITADEL via its v2 API, assigns the "member" role, and triggers email verification. Once the invited user verifies their email and logs in, the existing `ensureMemberOnSignIn()` flow creates their Firestore member record and routes them through onboarding.
 
 ## Requirements
-<!-- Will be generated in /kiro:spec-requirements phase -->
 
+### Requirement 1: Admin User Invitation Form
+**Objective:** As an administrator, I want to invite new users by entering their name and email, so that I can onboard new members without accessing the ZITADEL console directly.
+
+#### Acceptance Criteria
+1. When an admin navigates to the user invitation page, the Portal.C Admin UI shall display a form with fields for given name, family name, and email address.
+2. When an admin submits the invitation form with valid data, the Portal.C API shall call the ZITADEL v2 API to create a new human user.
+3. When the ZITADEL user is successfully created, the Portal.C API shall display a success message with the invited user's email.
+4. If the email address is already registered in ZITADEL, the Portal.C API shall display an error message indicating the user already exists.
+5. If the ZITADEL API call fails, the Portal.C API shall display an error message with the failure reason.
+
+### Requirement 2: ZITADEL User Creation via API
+**Objective:** As the system, I want to create users in ZITADEL programmatically, so that user provisioning is automated and consistent.
+
+#### Acceptance Criteria
+1. When a user creation request is received, the Portal.C API shall authenticate to ZITADEL using a service user Personal Access Token (PAT).
+2. When creating a user, the Portal.C API shall send a POST request to the ZITADEL v2 users endpoint with given name, family name, and email.
+3. When creating a user, the Portal.C API shall request ZITADEL to send a verification email automatically (sendCode).
+4. The Portal.C API shall store the ZITADEL service user PAT as a server-side environment variable, never exposing it to the client.
+
+### Requirement 3: Role Assignment
+**Objective:** As an administrator, I want invited users to automatically receive the "member" role, so that they have appropriate access upon first login.
+
+#### Acceptance Criteria
+1. When a user is successfully created in ZITADEL, the Portal.C API shall assign the "member" project role to the new user via the ZITADEL API.
+2. If role assignment fails after user creation, the Portal.C API shall display a warning indicating the user was created but role assignment failed.
+
+### Requirement 4: Access Control
+**Objective:** As the system, I want to restrict the invitation feature to administrators only, so that unauthorized users cannot create new accounts.
+
+#### Acceptance Criteria
+1. The Portal.C Admin UI shall only display the user invitation page to authenticated users with the "admin" role.
+2. When a non-admin user attempts to access the invitation API endpoint, the Portal.C API shall return an authorization error.
+3. When an unauthenticated user attempts to access the invitation API endpoint, the Portal.C API shall return an authentication error.
+
+### Requirement 5: Invited User Login Flow
+**Objective:** As an invited user, I want to verify my email and log in seamlessly, so that I can start using Portal.C after being invited.
+
+#### Acceptance Criteria
+1. When an invited user clicks the verification link in the email, ZITADEL shall verify their email address and allow them to set a password.
+2. When a verified invited user logs in for the first time, the existing `ensureMemberOnSignIn()` shall create their Firestore member record.
+3. When a newly created member logs in, the Portal.C middleware shall redirect them to the onboarding flow.

--- a/.kiro/specs/zitadel-user-invitation/requirements.md
+++ b/.kiro/specs/zitadel-user-invitation/requirements.md
@@ -1,0 +1,8 @@
+# Requirements Document
+
+## Project Description (Input)
+Admin user invitation feature: Administrators can create new ZITADEL users from Portal.C's custom UI. The system uses ZITADEL v2 API (POST /v2/users) to create human users with "member" role. Admin fills in user details (name, email), ZITADEL sends verification email automatically (sendCode). After the invited user verifies email and logs in, ensureMemberOnSignIn() creates the Firestore member record as usual. Requires service user PAT for ZITADEL API authentication.
+
+## Requirements
+<!-- Will be generated in /kiro:spec-requirements phase -->
+

--- a/.kiro/specs/zitadel-user-invitation/spec.json
+++ b/.kiro/specs/zitadel-user-invitation/spec.json
@@ -1,22 +1,22 @@
 {
   "feature_name": "zitadel-user-invitation",
   "created_at": "2026-04-10T11:55:00.000Z",
-  "updated_at": "2026-04-10T11:55:00.000Z",
+  "updated_at": "2026-04-10T12:05:00.000Z",
   "language": "en",
-  "phase": "initialized",
+  "phase": "implementation",
   "approvals": {
     "requirements": {
-      "generated": false,
-      "approved": false
+      "generated": true,
+      "approved": true
     },
     "design": {
-      "generated": false,
-      "approved": false
+      "generated": true,
+      "approved": true
     },
     "tasks": {
-      "generated": false,
-      "approved": false
+      "generated": true,
+      "approved": true
     }
   },
-  "ready_for_implementation": false
+  "ready_for_implementation": true
 }

--- a/.kiro/specs/zitadel-user-invitation/spec.json
+++ b/.kiro/specs/zitadel-user-invitation/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "zitadel-user-invitation",
+  "created_at": "2026-04-10T11:55:00.000Z",
+  "updated_at": "2026-04-10T11:55:00.000Z",
+  "language": "en",
+  "phase": "initialized",
+  "approvals": {
+    "requirements": {
+      "generated": false,
+      "approved": false
+    },
+    "design": {
+      "generated": false,
+      "approved": false
+    },
+    "tasks": {
+      "generated": false,
+      "approved": false
+    }
+  },
+  "ready_for_implementation": false
+}

--- a/.kiro/specs/zitadel-user-invitation/tasks.md
+++ b/.kiro/specs/zitadel-user-invitation/tasks.md
@@ -1,0 +1,20 @@
+# Implementation Tasks
+
+## Task 1: Create ZITADEL admin API client
+- [x] Create `lib/zitadel/admin-api.ts`
+- [x] Implement `createZitadelUser(givenName, familyName, email)` calling POST /v2/users
+- [x] Implement `assignUserGrant(userId, role)` calling POST /management/v1/users/{userId}/grants
+- [x] Use env vars: ZITADEL_SERVICE_USER_PAT, ZITADEL_ISSUER, ZITADEL_PROJECT_ID
+
+## Task 2: Create server action
+- [x] Create `app/actions/users.ts`
+- [x] Implement `inviteUserAction` with admin check, validation, ZITADEL API calls
+- [x] Handle errors (duplicate user, API failure, role assignment failure)
+
+## Task 3: Create UI components
+- [x] Create `components/admin/InviteUserForm.tsx` (client component)
+- [x] Create `app/admin/invite/page.tsx` (server component with admin guard)
+
+## Task 4: Update admin navigation
+- [x] Add nav link in `app/admin/layout.tsx`
+- [x] Add dashboard card in `app/admin/page.tsx`

--- a/app/actions/users.ts
+++ b/app/actions/users.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { isAdmin } from '@/lib/auth';
-import { createZitadelUser, assignUserGrant } from '@/lib/zitadel/admin-api';
+import { createZitadelUser, assignUserGrant, sendPasswordResetEmail } from '@/lib/zitadel/admin-api';
 
 export interface InviteUserFormState {
   error: string | null;
@@ -55,8 +55,18 @@ export async function inviteUserAction(
     };
   }
 
+  try {
+    await sendPasswordResetEmail(userId);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'メール送信に失敗しました。';
+    return {
+      error: null,
+      success: `ユーザー（${email}）を作成・ロール付与しましたが、パスワード設定メールの送信に失敗しました: ${message}。ZITADELコンソールから手動で再送してください。`,
+    };
+  }
+
   return {
     error: null,
-    success: `${familyName} ${givenName}（${email}）を招待しました。認証メールが送信されます。`,
+    success: `${familyName} ${givenName}（${email}）を招待しました。パスワード設定メールが送信されます。`,
   };
 }

--- a/app/actions/users.ts
+++ b/app/actions/users.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { isAdmin } from '@/lib/auth';
-import { createZitadelUser, assignUserGrant, sendPasswordResetEmail } from '@/lib/zitadel/admin-api';
+import { createZitadelUser, assignUserGrant } from '@/lib/zitadel/admin-api';
 
 export interface InviteUserFormState {
   error: string | null;
@@ -55,18 +55,8 @@ export async function inviteUserAction(
     };
   }
 
-  try {
-    await sendPasswordResetEmail(userId);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'メール送信に失敗しました。';
-    return {
-      error: null,
-      success: `ユーザー（${email}）を作成・ロール付与しましたが、パスワード設定メールの送信に失敗しました: ${message}。ZITADELコンソールから手動で再送してください。`,
-    };
-  }
-
   return {
     error: null,
-    success: `${familyName} ${givenName}（${email}）を招待しました。パスワード設定メールが送信されます。`,
+    success: `${familyName} ${givenName}（${email}）を招待しました。認証メールが送信されます。`,
   };
 }

--- a/app/actions/users.ts
+++ b/app/actions/users.ts
@@ -1,0 +1,62 @@
+'use server';
+
+import { isAdmin } from '@/lib/auth';
+import { createZitadelUser, assignUserGrant } from '@/lib/zitadel/admin-api';
+
+export interface InviteUserFormState {
+  error: string | null;
+  success: string | null;
+}
+
+export async function inviteUserAction(
+  _prevState: InviteUserFormState,
+  formData: FormData
+): Promise<InviteUserFormState> {
+  const admin = await isAdmin();
+  if (!admin) {
+    return { error: '管理者権限が必要です。', success: null };
+  }
+
+  const givenName = (formData.get('givenName') as string | null)?.trim();
+  const familyName = (formData.get('familyName') as string | null)?.trim();
+  const email = (formData.get('email') as string | null)?.trim();
+
+  if (!givenName) {
+    return { error: '名（givenName）を入力してください。', success: null };
+  }
+  if (!familyName) {
+    return { error: '姓（familyName）を入力してください。', success: null };
+  }
+  if (!email) {
+    return { error: 'メールアドレスを入力してください。', success: null };
+  }
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    return { error: 'メールアドレスの形式が正しくありません。', success: null };
+  }
+
+  let userId: string;
+  try {
+    const result = await createZitadelUser(givenName, familyName, email);
+    userId = result.userId;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'ユーザー作成に失敗しました。';
+    return { error: `ユーザー作成エラー: ${message}`, success: null };
+  }
+
+  try {
+    await assignUserGrant(userId, ['member']);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'ロール付与に失敗しました。';
+    return {
+      error: null,
+      success: `ユーザー（${email}）を作成しましたが、memberロールの付与に失敗しました: ${message}。ZITADELコンソールで手動設定してください。`,
+    };
+  }
+
+  return {
+    error: null,
+    success: `${familyName} ${givenName}（${email}）を招待しました。認証メールが送信されます。`,
+  };
+}

--- a/app/actions/users.ts
+++ b/app/actions/users.ts
@@ -22,11 +22,20 @@ export async function inviteUserAction(
   const email = (formData.get('email') as string | null)?.trim();
 
   if (!givenName) {
-    return { error: '名（givenName）を入力してください。', success: null };
+    return { error: '名（Given Name）を入力してください。', success: null };
   }
   if (!familyName) {
-    return { error: '姓（familyName）を入力してください。', success: null };
+    return { error: '姓（Family Name）を入力してください。', success: null };
   }
+
+  const asciiOnly = /^[a-zA-Z]+$/;
+  if (!asciiOnly.test(givenName)) {
+    return { error: '名は英字（a-z）のみで入力してください。', success: null };
+  }
+  if (!asciiOnly.test(familyName)) {
+    return { error: '姓は英字（a-z）のみで入力してください。', success: null };
+  }
+
   if (!email) {
     return { error: 'メールアドレスを入力してください。', success: null };
   }
@@ -36,9 +45,11 @@ export async function inviteUserAction(
     return { error: 'メールアドレスの形式が正しくありません。', success: null };
   }
 
+  const username = `${givenName.toLowerCase()}.${familyName.toLowerCase()}`;
+
   let userId: string;
   try {
-    const result = await createZitadelUser(givenName, familyName, email);
+    const result = await createZitadelUser(givenName, familyName, email, username);
     userId = result.userId;
   } catch (error) {
     const message = error instanceof Error ? error.message : 'ユーザー作成に失敗しました。';

--- a/app/admin/invite/page.tsx
+++ b/app/admin/invite/page.tsx
@@ -1,0 +1,26 @@
+import { isAdmin } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import { InviteUserForm } from "@/components/admin/InviteUserForm";
+
+export default async function AdminInvitePage() {
+  const admin = await isAdmin();
+
+  if (!admin) {
+    redirect("/events");
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold mb-2">メンバー招待</h1>
+        <p className="text-gray-600">
+          新しいメンバーをZITADELに登録し、招待メールを送信します。
+        </p>
+      </div>
+
+      <div className="bg-white rounded-lg shadow-md p-6 max-w-lg">
+        <InviteUserForm />
+      </div>
+    </div>
+  );
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -53,6 +53,12 @@ export default async function AdminLayout({
             >
               メンバーHR
             </Link>
+            <Link
+              href="/admin/invite"
+              className="rounded-full border border-gray-200 px-3 py-1 hover:bg-gray-50"
+            >
+              メンバー招待
+            </Link>
           </nav>
         </div>
       </div>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -110,6 +110,15 @@ export default async function AdminPage() {
             基本情報・イベント参加数の確認
           </p>
         </Link>
+        <Link
+          href="/admin/invite"
+          className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition hover:shadow-md"
+        >
+          <h2 className="text-lg font-semibold mb-2">メンバー招待</h2>
+          <p className="text-sm text-gray-600">
+            新しいメンバーをZITADELに登録・招待
+          </p>
+        </Link>
       </div>
     </div>
   );

--- a/components/admin/InviteUserForm.tsx
+++ b/components/admin/InviteUserForm.tsx
@@ -43,26 +43,34 @@ export function InviteUserForm() {
 
       <div className="grid gap-4 md:grid-cols-2">
         <div>
-          <label className="block text-sm font-medium mb-2">姓</label>
+          <label className="block text-sm font-medium mb-2">姓（英字）</label>
           <input
             type="text"
             name="familyName"
             className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-            placeholder="山田"
+            placeholder="Yamada"
+            pattern="[a-zA-Z]+"
+            title="英字のみ入力してください"
             required
           />
         </div>
         <div>
-          <label className="block text-sm font-medium mb-2">名</label>
+          <label className="block text-sm font-medium mb-2">名（英字）</label>
           <input
             type="text"
             name="givenName"
             className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-            placeholder="太郎"
+            placeholder="Taro"
+            pattern="[a-zA-Z]+"
+            title="英字のみ入力してください"
             required
           />
         </div>
       </div>
+
+      <p className="text-xs text-gray-500">
+        ログイン名は自動生成されます（例: taro.yamada）
+      </p>
 
       <div>
         <label className="block text-sm font-medium mb-2">メールアドレス</label>

--- a/components/admin/InviteUserForm.tsx
+++ b/components/admin/InviteUserForm.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useActionState } from 'react';
+import { useFormStatus } from 'react-dom';
+import { Button } from '@openameba/spindle-ui';
+import '@openameba/spindle-ui/Button/Button.css';
+import {
+  inviteUserAction,
+  type InviteUserFormState,
+} from '@/app/actions/users';
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" size="large" variant="contained" disabled={pending}>
+      {pending ? '招待中...' : 'メンバーを招待'}
+    </Button>
+  );
+}
+
+export function InviteUserForm() {
+  const [state, formAction] = useActionState<InviteUserFormState, FormData>(
+    inviteUserAction,
+    {
+      error: null,
+      success: null,
+    }
+  );
+
+  return (
+    <form action={formAction} className="space-y-4">
+      {state.error && (
+        <div className="rounded-lg border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+          {state.error}
+        </div>
+      )}
+
+      {state.success && (
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+          {state.success}
+        </div>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <label className="block text-sm font-medium mb-2">姓</label>
+          <input
+            type="text"
+            name="familyName"
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="山田"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-2">名</label>
+          <input
+            type="text"
+            name="givenName"
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="太郎"
+            required
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-2">メールアドレス</label>
+        <input
+          type="email"
+          name="email"
+          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="taro.yamada@example.com"
+          required
+        />
+      </div>
+
+      <div className="pt-2">
+        <SubmitButton />
+      </div>
+
+      <p className="text-xs text-gray-500">
+        招待されたユーザーには認証メールが送信されます。メール認証後、初回ログイン時にオンボーディングが開始されます。
+      </p>
+    </form>
+  );
+}

--- a/lib/zitadel/admin-api.ts
+++ b/lib/zitadel/admin-api.ts
@@ -1,0 +1,99 @@
+/**
+ * ZITADEL Admin API client for user management.
+ * Uses a service user PAT to authenticate against the ZITADEL v2 API.
+ */
+
+interface CreateUserResponse {
+  userId: string;
+  details?: {
+    sequence: number;
+    changeDate: string;
+    resourceOwner: string;
+  };
+  emailCode?: string;
+}
+
+interface ZitadelErrorDetail {
+  message?: string;
+}
+
+interface ZitadelErrorResponse {
+  code?: number;
+  message?: string;
+  details?: ZitadelErrorDetail[];
+}
+
+function getConfig() {
+  const issuer = process.env.ZITADEL_ISSUER;
+  const pat = process.env.ZITADEL_SERVICE_USER_PAT;
+  const projectId = process.env.ZITADEL_PROJECT_ID;
+
+  if (!issuer) throw new Error("ZITADEL_ISSUER is not set");
+  if (!pat) throw new Error("ZITADEL_SERVICE_USER_PAT is not set");
+  if (!projectId) throw new Error("ZITADEL_PROJECT_ID is not set");
+
+  return { issuer, pat, projectId };
+}
+
+export async function createZitadelUser(
+  givenName: string,
+  familyName: string,
+  email: string
+): Promise<{ userId: string }> {
+  const { issuer, pat } = getConfig();
+
+  const response = await fetch(`${issuer}/v2/users/human`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${pat}`,
+    },
+    body: JSON.stringify({
+      profile: {
+        givenName,
+        familyName,
+      },
+      email: {
+        email,
+        sendCode: {},
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = (await response.json().catch(() => null)) as ZitadelErrorResponse | null;
+    const message = errorBody?.message ?? `ZITADEL API error: ${response.status}`;
+    throw new Error(message);
+  }
+
+  const data = (await response.json()) as CreateUserResponse;
+  return { userId: data.userId };
+}
+
+export async function assignUserGrant(
+  userId: string,
+  roleKeys: string[]
+): Promise<void> {
+  const { issuer, pat, projectId } = getConfig();
+
+  const response = await fetch(
+    `${issuer}/management/v1/users/${userId}/grants`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${pat}`,
+      },
+      body: JSON.stringify({
+        projectId,
+        roleKeys,
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const errorBody = (await response.json().catch(() => null)) as ZitadelErrorResponse | null;
+    const message = errorBody?.message ?? `Role assignment failed: ${response.status}`;
+    throw new Error(message);
+  }
+}

--- a/lib/zitadel/admin-api.ts
+++ b/lib/zitadel/admin-api.ts
@@ -55,7 +55,7 @@ export async function createZitadelUser(
       },
       email: {
         email,
-        sendCode: {},
+        isVerified: true,
       },
     }),
   });
@@ -68,6 +68,32 @@ export async function createZitadelUser(
 
   const data = (await response.json()) as CreateUserResponse;
   return { userId: data.userId };
+}
+
+export async function sendPasswordResetEmail(
+  userId: string
+): Promise<void> {
+  const { issuer, pat } = getConfig();
+
+  const response = await fetch(
+    `${issuer}/v2/users/${userId}/password_reset`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${pat}`,
+      },
+      body: JSON.stringify({
+        sendLink: {},
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const errorBody = (await response.json().catch(() => null)) as ZitadelErrorResponse | null;
+    const message = errorBody?.message ?? `Password reset email failed: ${response.status}`;
+    throw new Error(message);
+  }
 }
 
 export async function assignUserGrant(

--- a/lib/zitadel/admin-api.ts
+++ b/lib/zitadel/admin-api.ts
@@ -38,7 +38,8 @@ function getConfig() {
 export async function createZitadelUser(
   givenName: string,
   familyName: string,
-  email: string
+  email: string,
+  username: string
 ): Promise<{ userId: string }> {
   const { issuer, pat } = getConfig();
 
@@ -49,6 +50,7 @@ export async function createZitadelUser(
       Authorization: `Bearer ${pat}`,
     },
     body: JSON.stringify({
+      userName: username,
       profile: {
         givenName,
         familyName,

--- a/lib/zitadel/admin-api.ts
+++ b/lib/zitadel/admin-api.ts
@@ -55,7 +55,7 @@ export async function createZitadelUser(
       },
       email: {
         email,
-        isVerified: true,
+        sendCode: {},
       },
     }),
   });
@@ -68,32 +68,6 @@ export async function createZitadelUser(
 
   const data = (await response.json()) as CreateUserResponse;
   return { userId: data.userId };
-}
-
-export async function sendPasswordResetEmail(
-  userId: string
-): Promise<void> {
-  const { issuer, pat } = getConfig();
-
-  const response = await fetch(
-    `${issuer}/v2/users/${userId}/password_reset`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${pat}`,
-      },
-      body: JSON.stringify({
-        sendLink: {},
-      }),
-    }
-  );
-
-  if (!response.ok) {
-    const errorBody = (await response.json().catch(() => null)) as ZitadelErrorResponse | null;
-    const message = errorBody?.message ?? `Password reset email failed: ${response.status}`;
-    throw new Error(message);
-  }
 }
 
 export async function assignUserGrant(


### PR DESCRIPTION
## Summary
This PR implements an admin-driven user invitation feature that allows Portal.C administrators to invite new members directly from the application UI. The system creates users in ZITADEL via the v2 API, assigns the "member" role, and triggers email verification without requiring console access.

## Key Changes

### New Files
- **`lib/zitadel/admin-api.ts`** - ZITADEL Management API client with two functions:
  - `createZitadelUser()` - Creates a human user in ZITADEL v2 API with email verification
  - `assignUserGrant()` - Assigns the "member" role to the created user
  - Authenticates using service user Personal Access Token (PAT)

- **`app/actions/users.ts`** - Server action for form submission:
  - `inviteUserAction()` - Validates input, checks admin permissions, calls ZITADEL APIs, handles errors gracefully
  - Returns success/error state for UI feedback

- **`components/admin/InviteUserForm.tsx`** - Client component for the invitation form:
  - Fields for given name, family name, and email address
  - Uses `useActionState` hook for form state management
  - Displays success/error messages with styled alerts
  - Follows existing Portal.C patterns (spindle-ui Button component)

- **`app/admin/invite/page.tsx`** - Admin page with server-side auth guard:
  - Redirects non-admin users to `/events`
  - Renders the invitation form with descriptive header

- **`.kiro/specs/zitadel-user-invitation/`** - Feature specification documents:
  - `requirements.md` - Detailed acceptance criteria
  - `design.md` - Technical architecture and API flow
  - `tasks.md` - Implementation checklist
  - `spec.json` - Feature metadata

### Modified Files
- **`app/admin/layout.tsx`** - Added "メンバー招待" navigation link
- **`app/admin/page.tsx`** - Added dashboard card linking to invitation feature

## Implementation Details

- **Security**: Service user PAT stored server-side only via environment variables; admin role verified in both layout redirect and server action
- **Error Handling**: Graceful handling of duplicate users, API failures, and partial failures (user created but role assignment failed)
- **User Experience**: Japanese UI text; email verification triggered automatically; invited users complete onboarding on first login via existing `ensureMemberOnSignIn()` flow
- **Environment Variables Required**:
  - `ZITADEL_SERVICE_USER_PAT` - Service user Personal Access Token
  - `ZITADEL_ISSUER` - ZITADEL instance URL
  - `ZITADEL_PROJECT_ID` - Project ID for role assignment

https://claude.ai/code/session_01M6oMkVGLMzb3SkinZeZaCa