### PR TITLE
Exclude static assets from auth middleware to fix PWA icons

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -100,5 +100,7 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!api|_next|favicon.ico).*)"],
+  // Exclude API routes, Next.js internals, and static asset files
+  // (e.g. /icons/*.png, /manifest.webmanifest) so PWA resources stay publicly accessible.
+  matcher: ["/((?!api|_next|.*\\..*).*)"],
 }


### PR DESCRIPTION
### Motivation
- The auth `middleware` was matching requests for manifest and icon files (e.g. `/manifest.webmanifest`, `/icons/*.png`), causing unauthenticated fetches to be redirected to `/login` and preventing PWA installers from obtaining icons.

### Description
- Update `middleware.ts` `config.matcher` to also exclude paths that contain a file extension so static assets (e.g. `/manifest.webmanifest`, `/icons/*.png`) and Next.js internals remain publicly accessible, allowing the PWA manifest and icons to be fetched without authentication.

### Testing
- Ran `npm run lint`, which completed successfully with no ESLint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd80d8dc80832cbf9178a193498c11)