### PR TITLE
Fix timezone handling to use JST consistently

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,6 +65,13 @@ function normalizeTimeValue(value: string | null): string {
     return value.length >= 5 ? value.slice(0, 5) : value;
 }
 
+// JST(Asia/Tokyo)基準の曜日(0=日〜6=土)を返す。
+// サーバーのタイムゾーンに依存せず、JSTの0:00で曜日が切り替わるようにする。
+function getJstDayOfWeek(date: Date): number {
+    const jstMs = date.getTime() + 9 * 60 * 60 * 1000;
+    return new Date(jstMs).getUTCDay();
+}
+
 async function getTimeSlotMap(): Promise<Map<number, string>> {
     try {
         const db = getDb();
@@ -97,8 +104,8 @@ async function getTimeSlotMap(): Promise<Map<number, string>> {
 async function getTodayTimetableRows(params: { major: string; grade: number; baseDate: Date }) {
     const { major, grade, baseDate } = params;
 
-    // 日曜(0)/土曜(6)は基本表示なし
-    const dayOfWeek = baseDate.getDay();
+    // 日曜(0)/土曜(6)は基本表示なし（JST基準）
+    const dayOfWeek = getJstDayOfWeek(baseDate);
     if (dayOfWeek === 0 || dayOfWeek === 6) return [];
 
     try {
@@ -137,6 +144,7 @@ export default async function Home() {
     const now = new Date();
 
     const timetableDateLabel = now.toLocaleDateString("ja-JP", {
+        timeZone: "Asia/Tokyo",
         year: "numeric",
         month: "2-digit",
         day: "2-digit",


### PR DESCRIPTION
## Summary
This PR fixes timezone-related bugs by ensuring all date/time operations consistently use Japan Standard Time (JST/Asia/Tokyo) instead of relying on the server's local timezone.

## Key Changes
- Added `getJstDayOfWeek()` helper function that calculates the day of week based on JST (0=Sunday, 6=Saturday) regardless of server timezone
- Updated `getTodayTimetableRows()` to use `getJstDayOfWeek()` instead of `Date.getDay()` for weekend detection
- Added explicit `timeZone: "Asia/Tokyo"` parameter to the date formatting in the Home component to ensure the displayed date label uses JST

## Implementation Details
The `getJstDayOfWeek()` function converts the date to JST by adding 9 hours (9 * 60 * 60 * 1000 milliseconds) to the timestamp, then uses `getUTCDay()` on the adjusted time. This ensures consistent behavior across different server timezones where the application might be deployed.

https://claude.ai/code/session_01MwrYs6hwWm2vWVrttHLPef